### PR TITLE
Add internship weekly logs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ This repository tracks progress from my AutoStereo Software Engineering internsh
 - **Day 3:** Implemented the programs page for EDSO.
 - **Day 4:** Implemented the clients page for EDSO.
 - **Day 5:** Performed live testing and finalized code.
+
+## Weekly Logs
+- [Internship Logs](internship/README.md)

--- a/internship/README.md
+++ b/internship/README.md
@@ -1,0 +1,6 @@
+# Internship Weekly Log
+
+This folder contains weekly progress logs for my AutoStereo Software Engineering internship. Each page details the work completed during that specific week.
+
+## Weeks
+- [Week 1](week1.md)

--- a/internship/week1.md
+++ b/internship/week1.md
@@ -1,0 +1,11 @@
+# Week 1
+
+## Overview
+This week focused on setting up tools, building application features, and completing initial tests for the AutoStereo projects.
+
+## Day-by-Day Summary
+- **Day 1:** Set up tools, ran initial tests, and began front-end development.
+- **Day 2:** Built the PostgreSQL backend and EDSO dashboard using Vibe coding.
+- **Day 3:** Implemented the programs page for EDSO.
+- **Day 4:** Implemented the clients page for EDSO.
+- **Day 5:** Performed live testing and finalized code.


### PR DESCRIPTION
## Summary
- add folder for internship logs
- add Week 1 page based on README summary
- link to weekly logs from main README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685996846ef083208a918e0350cbe2d5