### PR TITLE
Add week 7 worklog for Jul 28-Aug 3, 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ This repository tracks progress from my AutoStereo Software Engineering internsh
 - **Day 5–6:** Attempted to build a gym entity with coach subset; build failed and rolled back.
 - **Day 7:** Planned fixes and next steps.
 
+### Week 7 (July 28–August 3, 2025)
+- **Day 1:** Built the Gym entity.
+- **Day 2–3:** Developed the "restap" React Native mobile app to track rest time between workout sets.
+- **Day 4–5:** Troubleshot issues related to the gym entity.
+- **Day 6:** Off.
+- **Day 7:** Completed the gym feature enabling coaches to manage clients by gym.
+
 ## Weekly Logs
 - [Internship Logs](internship/README.md)
 - [Detailed Summaries](weekly_summaries)

--- a/internship/README.md
+++ b/internship/README.md
@@ -9,3 +9,4 @@ This folder contains weekly progress logs for my AutoStereo Software Engineering
 - [Week 4](week4.md)
 - [Week 5](week5.md)
 - [Week 6](week6.md)
+- [Week 7](week7.md)

--- a/internship/week7.md
+++ b/internship/week7.md
@@ -1,0 +1,11 @@
+# Week 7 (July 28 - August 3, 2025)
+
+## Overview
+This week established a gym-centric workflow and introduced a new mobile app for tracking rest time. Initial development focused on building the Gym entity, followed by the "restap" React Native app. The week finished with gym feature completion after resolving implementation issues.
+
+## Day-by-Day Summary
+- **Day 1 (Mon Jul 28):** Built the Gym entity.
+- **Day 2-3 (Tue Jul 29 - Wed Jul 30):** Developed the "restap" React Native mobile app to track rest time between workout sets.
+- **Day 4-5 (Thu Jul 31 - Fri Aug 1):** Troubleshot issues related to the gym entity.
+- **Day 6 (Sat Aug 2):** Off.
+- **Day 7 (Sun Aug 3):** Completed the gym feature enabling coaches to manage clients by gym.


### PR DESCRIPTION
## Summary
- document progress on gym entity and restap mobile app
- reference week 7 in README and internship logs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68911baba97483209579b2e30896e452