### PR TITLE
Add week 8 worklog for Aug 4-10, 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ This repository tracks progress from my AutoStereo Software Engineering internsh
 - **Day 6:** Off.
 - **Day 7:** Completed the gym feature enabling coaches to manage clients by gym.
 
+### Week 8 (August 4–August 10, 2025)
+- **Day 1:** Resolved a git merge conflict by force pushing a rollback.
+- **Day 2:** Fixed minor CRUD operation issues in the app.
+- **Day 3:** Created a testbed gym and programs for universal client testing.
+- **Day 4:** Implemented an MCP server for testing and explored the GPT-5 model with IDEs like Lovable, Cursor, and ChatGPT.
+- **Day 5:** Began collecting feedback from beta test users.
+- **Day 6–7:** Built a personalized travel-route MCP server to validate local and virtual deployment.
+
 ## Weekly Logs
 - [Internship Logs](internship/README.md)
 - [Detailed Summaries](weekly_summaries)

--- a/internship/README.md
+++ b/internship/README.md
@@ -10,3 +10,4 @@ This folder contains weekly progress logs for my AutoStereo Software Engineering
 - [Week 5](week5.md)
 - [Week 6](week6.md)
 - [Week 7](week7.md)
+- [Week 8](week8.md)

--- a/internship/week8.md
+++ b/internship/week8.md
@@ -1,0 +1,12 @@
+# Week 8 (August 4 - August 10, 2025)
+
+## Overview
+This week focused on stabilizing development workflows, expanding testing infrastructure, and experimenting with MCP server integrations. Work included resolving merge conflicts, refining CRUD features, gathering beta feedback, and prototyping a personalized travel-route MCP server.
+
+## Day-by-Day Summary
+- **Day 1 (Mon Aug 4):** Encountered a git merge conflict during debugging and force pushed a rollback to fix the issue.
+- **Day 2 (Tue Aug 5):** Fixed minor CRUD operation issues in the app.
+- **Day 3 (Wed Aug 6):** Created a testbed gym and programs to test clients in a universal setting.
+- **Day 4 (Thu Aug 7):** Implemented an MCP server for testing and navigated the GPT-5 model with IDEs like Lovable, Cursor, and ChatGPT.
+- **Day 5 (Fri Aug 8):** Started collecting feedback from beta test users.
+- **Day 6-7 (Sat Aug 9 - Sun Aug 10):** Built a personalized travel-route MCP server that accepts user input and returns trip routes, testing local and virtual deployment.


### PR DESCRIPTION
## Summary
- record week 8 progress covering merge conflict resolution, CRUD fixes, testbed gym, MCP server work, beta feedback, and a travel-route MCP prototype
- link week 8 log from internship README
- include week 8 summary in the repository README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a30d9c80c8320a8f61575824aad58