### PR TITLE
Add week 9 internship worklog

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ This repository tracks progress from my Autosterea Software Engineering internsh
 - **Day 5:** Began collecting feedback from beta test users.
 - **Day 6–7:** Built a personalized travel-route MCP server to validate local and virtual deployment.
 
+### Week 9 (August 11–August 17, 2025)
+- **Day 1:** Built a personalized travel-route MCP server for local and virtual testing.
+- **Day 2–3:** Fixed UI on the /gyms page preparing for a gyms calendar where clients can browse assigned workouts.
+- **Day 4:** Gathered UX requirements, created the database schema and frontend components, and parsed 50 movement metrics into CSV for client tracking.
+- **Day 5:** Resolved issues from the "measures" feature syncing gym and client pages and built an Aurora-alert MCP server to predict auroras using US PO data.
+- **Day 6:** Ran Restap EAS build and locally tested the Aurora-alert server over HTTP for deployment.
+- **Day 7:** Off.
 ## Weekly Logs
 - [Internship Logs](internship/README.md)
 - [Detailed Summaries](weekly_summaries)

--- a/internship/README.md
+++ b/internship/README.md
@@ -11,3 +11,4 @@ This folder contains weekly progress logs for my AutoStereo Software Engineering
 - [Week 6](week6.md)
 - [Week 7](week7.md)
 - [Week 8](week8.md)
+- [Week 9](week9.md)

--- a/internship/week9.md
+++ b/internship/week9.md
@@ -1,0 +1,12 @@
+# Week 9 (August 11 - August 17, 2025)
+
+## Overview
+This week advanced MCP server development and refined the coach app's gym interface. Work included gathering UX requirements, designing data structures, synchronizing metrics between pages, and preparing an Aurora-alert server for broader deployment.
+
+## Day-by-Day Summary
+- **Day 1 (Mon Aug 11):** Built a personalized travel-route MCP server that accepts user input and returns trip routes, testing local and virtual deployment.
+- **Day 2-3 (Tue Aug 12 - Wed Aug 13):** Fixed UI on the /gyms page in the coach app to prepare for a gyms calendar where clients can browse assigned workouts.
+- **Day 4 (Thu Aug 14):** Obtained UX requirements, built the database schema and frontend components, and parsed 50 movement metrics into CSV for client performance tracking.
+- **Day 5 (Fri Aug 15):** Resolved issues from the "measures" feature syncing gym and client pages, and built an MCP-based Aurora-alert to predict auroras using US PO data.
+- **Day 6 (Sat Aug 16):** Ran Restap EAS build and locally tested the Aurora-alert MCP server over HTTP for web deployment.
+- **Day 7 (Sun Aug 17):** Off.


### PR DESCRIPTION
## Summary
- document Week 9 progress including MCP server work, gym UI fixes, and Aurora-alert development
- link new entry in internship index
- expand root README with Week 9 highlights

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a27f1eff4883208eaa5c0cdcec88e3