### PR TITLE
Add week 11 log and Codex instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS Instructions for Codex
+
+These guidelines apply to the entire repository when working in the Codex environment.
+
+- Maintain weekly work logs in the `internship/` directory as `week{number}.md`.
+- Use the format:
+  - `# Week X (Date Range)`
+  - `## Overview`
+  - `## Day-by-Day Summary` with bullet points for each day.
+- For the coach backend app, keep features documented and synced with the mobile app, especially subscription and attendance systems.
+- When updating backend functionality, ensure API endpoint documentation is refreshed accordingly.
+- Run `npm test` before committing, even if the project lacks tests.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ This repository tracks progress from my Autosterea Software Engineering internsh
 - **Day 5:** Enhanced the sound/haptic system of the "restap" mobile app so users can tell when their sets are done without watching the screen.
 - **Day 6-7:** Off.
 
+### Week 11 (August 25–August 31, 2025)
+- **Day 1-2:** Built a flexible subscription system letting coaches create tiered membership plans with attendance limits across custom time frames.
+- **Day 3:** Synced class attendance dates with subscription periods to automatically enforce limits.
+- **Day 4:** Fixed a race condition that could overcount check-ins and added repository guidelines for the Codex environment.
+- **Day 5:** Synced the backend server with attendance tracking and the mobile app to honor subscription limits.
+- **Day 6:** Updated backend Coach app API documentation to stay aligned with mobile development.
+- **Day 7:** Off.
+
 ## Weekly Logs
 - [Internship Logs](internship/README.md)
 - [Detailed Summaries](weekly_summaries)

--- a/internship/README.md
+++ b/internship/README.md
@@ -13,3 +13,4 @@ This folder contains weekly progress logs for my Autosterea Software Engineering
 - [Week 8](week8.md)
 - [Week 9](week9.md)
 - [Week 10](week10.md)
+- [Week 11](week11.md)

--- a/internship/week11.md
+++ b/internship/week11.md
@@ -1,0 +1,12 @@
+# Week 11 (August 25 - August 31, 2025)
+
+## Overview
+This week established a flexible subscription system for gym client management, aligned attendance tracking with subscription limits, resolved a race condition in attendance counts, and updated backend integrations and documentation.
+
+## Day-by-Day Summary
+- **Day 1-2 (Mon Aug 25 - Tue Aug 26):** Set up the subscription system so the admin coach can create membership plans with name, price, user-type category, and total attendance limits across days, weeks, months, years, or specific date ranges.
+- **Day 3 (Wed Aug 27):** Synced class attendance dates with subscription time frames so coaches can automatically enforce attendance limits.
+- **Day 4 (Thu Aug 28):** Fixed a race condition causing discrepancies between total attendance and the active plan's limit, preventing clients from exceeding their maximum check-ins. Created an AGENTS.md file for the Codex environment to guide development of the coach backend app's features.
+- **Day 5 (Fri Aug 29):** Synced the backend server with the attendance system and mobile app to manage clients according to subscription limits.
+- **Day 6 (Sat Aug 30):** Updated backend Coach app API endpoint documentation to keep mobile app development aligned with current features.
+- **Day 7 (Sun Aug 31):** Off.


### PR DESCRIPTION
## Summary
- Document week 11 progress on subscription, attendance sync, race condition fixes, backend syncing, and API updates
- Introduce AGENTS.md with guidelines for maintaining work logs and backend documentation in the Codex environment
- Summarize week 11 in the main README and link the new log in the internship index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b50ae0084c83209481643b5ff1610e