### PR TITLE
Add week 12 worklog and update summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ This repository tracks progress from my Autosterea Software Engineering internsh
 - **Day 6:** Updated backend Coach app API documentation to stay aligned with mobile development.
 - **Day 7:** Off.
 
+### Week 12 (September 1–September 7, 2025)
+- **Day 1:** Added attendance error handling in the mobile app to block check-ins at the limit.
+- **Day 2:** Built a gyms page with coach management and client read-only view, and fixed Google login via the Firebase EDSO programmer app.
+- **Day 3:** Added a "Measures" tab for clients.
+- **Day 4:** Added an "Attendance" tab so clients can view their status and progress.
+- **Day 5:** Fixed attendance enforcement by applying membership time domains and limits to a single plan.
+- **Day 6:** Resolved a race condition involving enrollment status, attendance caps, and membership time domains so renewed plans apply correctly.
+- **Day 7:** Off.
+
 ## Weekly Logs
 - [Internship Logs](internship/README.md)
 - [Detailed Summaries](weekly_summaries)

--- a/internship/README.md
+++ b/internship/README.md
@@ -14,3 +14,4 @@ This folder contains weekly progress logs for my Autosterea Software Engineering
 - [Week 9](week9.md)
 - [Week 10](week10.md)
 - [Week 11](week11.md)
+- [Week 12](week12.md)

--- a/internship/week12.md
+++ b/internship/week12.md
@@ -1,0 +1,13 @@
+# Week 12 (September 1 - September 7, 2025)
+
+## Overview
+This week expanded client-facing features in the mobile app, refined gym management and authentication, and resolved attendance issues by aligning limits with membership plans.
+
+## Day-by-Day Summary
+- **Day 1 (Mon Sep 1):** Added attendance error handling on the frontend to block check-ins once clients reach their limit.
+- **Day 2 (Tue Sep 2):** Built a gyms page where coaches can manage gyms and clients can view them read-only, and fixed Google login through the Firebase EDSO programmer app.
+- **Day 3 (Wed Sep 3):** Introduced a "Measures" tab so clients can track body metrics.
+- **Day 4 (Thu Sep 4):** Added an "Attendance" tab for clients to monitor their status and progress.
+- **Day 5 (Fri Sep 5):** Corrected attendance limits by honoring the active membership's time domain and cap for a single plan.
+- **Day 6 (Sat Sep 6):** Resolved a race condition by applying the correct attendance and time domain limits when clients renew memberships, preventing enrollment errors.
+- **Day 7 (Sun Sep 7):** Off.


### PR DESCRIPTION
## Summary
- document week 12 efforts in a new worklog file covering gym management, client tabs, and attendance fixes
- link week 12 in internship README and expand the main README with a week 12 summary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be3c0d58448320974663cc1e90f80d