### PR TITLE
Add week 14 internship log and update summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ This repository tracks progress from my Autosterea Software Engineering internsh
 - **Day 6:** Off.
 - **Day 7:** Updated the EDSO Coach mobile app for Expo SDK 54 and React Native 19.0.0.
 
+### Week 14 (September 15–September 21, 2025)
+- **Day 1:** Corrected client attendance analysis requests by passing the client JWT token to the coach backend.
+- **Day 2-3:** Repaired attendance leaderboard calls by using the client token and validating the data loads in the mobile app.
+- **Day 4-6:** Polished the /measure, /measures/history, /gyms, /attendance, and /leaderboard screens for consistent layouts.
+- **Day 7:** Off.
+
 ## Weekly Logs
 - [Internship Logs](internship/README.md)
 - [Detailed Summaries](weekly_summaries)

--- a/internship/README.md
+++ b/internship/README.md
@@ -16,3 +16,4 @@ This folder contains weekly progress logs for my Autosterea Software Engineering
 - [Week 11](week11.md)
 - [Week 12](week12.md)
 - [Week 13](week13.md)
+- [Week 14](week14.md)

--- a/internship/week14.md
+++ b/internship/week14.md
@@ -1,0 +1,13 @@
+# Week 14 (September 15 - September 21, 2025)
+
+## Overview
+Resolved JWT mix-ups blocking attendance analytics and leaderboard data in the mobile app, then refined the layout of all related measurement, gym, and attendance screens.
+
+## Day-by-Day Summary
+- **Day 1 (Mon Sep 15):** Fixed the attendance analysis requests by ensuring the client JWT token was used when fetching streak status, total attendance dates, and preference data from the coach backend.
+- **Day 2 (Tue Sep 16):** Corrected the leaderboard API calls to send the client token instead of the coach token when requesting attendance standings.
+- **Day 3 (Wed Sep 17):** Validated the leaderboard authentication fix across the mobile flows to confirm all leaderboard data loads with the client JWT.
+- **Day 4 (Thu Sep 18):** Polished the /measure and /measures/history screens, tightening spacing and aligning typography for the refreshed layout.
+- **Day 5 (Fri Sep 19):** Updated the /gyms screen styling to match the new layout patterns and improve hierarchy.
+- **Day 6 (Sat Sep 20):** Refined the /attendance and /leaderboard screens with consistent padding, colors, and responsive behavior.
+- **Day 7 (Sun Sep 21):** Off.


### PR DESCRIPTION
## Summary
- add the detailed Week 14 internship log covering JWT fixes and UI polish work
- extend the root README with a Week 14 summary and link the new log from the internship index

## Testing
- npm test *(fails: repository has no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d0650e62f083209723084638290dc1