### PR TITLE
Add week 15 internship log and README summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ This repository tracks progress from my Autosterea Software Engineering internsh
 - **Day 4-6:** Polished the /measure, /measures/history, /gyms, /attendance, and /leaderboard screens for consistent layouts.
 - **Day 7:** Off.
 
+### Week 15 (September 22–September 28, 2025)
+- **Day 1:** Fixed the mobile attendance and leaderboard pages to match the latest backend logic.
+- **Day 2:** Off.
+- **Day 3:** Documented the EDSO coach frontend and backend architecture to support the EDSO pay app.
+- **Day 4:** Implemented the modular EDSO pay app with EDCO coach login inside the EDSO ecosystem.
+- **Day 5:** Ran deployment tests for the EDSO pay app and confirmed a successful release.
+- **Day 6:** Off.
+- **Day 7:** Resolved git conflicts to finalize the updated EDSO pay implementation.
+
 ## Weekly Logs
 - [Internship Logs](internship/README.md)
 - [Detailed Summaries](weekly_summaries)

--- a/internship/week15.md
+++ b/internship/week15.md
@@ -1,0 +1,13 @@
+# Week 15 (September 22 - September 28, 2025)
+
+## Overview
+Refined the mobile attendance and leaderboard experiences, documented the EDSO coach architecture to support the new EDSO pay app, delivered the modular payment implementation with EDCO coach login, and ensured a clean deployment by resolving merge conflicts.
+
+## Day-by-Day Summary
+- **Day 1 (Mon Sep 22):** Fixed the mobile app's attendance and leaderboard pages to align frontend behavior with the latest backend data.
+- **Day 2 (Tue Sep 23):** Off.
+- **Day 3 (Wed Sep 24):** Documented the EDSO coach architecture across frontend and backend components to guide the EDSO pay app integration.
+- **Day 4 (Thu Sep 25):** Implemented the EDSO pay app with a modularized payment method in the EDSO ecosystem and enabled login via the EDCO coach flow.
+- **Day 5 (Fri Sep 26):** Ran deployment tests for the EDSO pay app prior to feature integration and confirmed a successful release.
+- **Day 6 (Sat Sep 27):** Off.
+- **Day 7 (Sun Sep 28):** Resolved git conflicts between the previous and new versions of the EDSO pay app to finalize the deployment branch.


### PR DESCRIPTION
## Summary
- add the Week 15 internship log covering mobile fixes and the new EDSO pay app work
- update the repository README with a Week 15 summary entry

## Testing
- npm test *(fails: missing package.json in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e29925cc8320947ccafdaff3e8f6