### PR TITLE
Add Week 30 internship log and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,15 @@ This repository tracks progress from my Autosterea Software Engineering internsh
 - **Day 6:** Implemented the order module.
 - **Day 7:** Refactored and organized code in `/orders`, `/catalog`, auth management, and the location selector.
 
+### Week 30 (January 5–January 11, 2026)
+- **Day 1:** Fixed the backend inventory filtering logic and unified documentation for future build planning.
+- **Day 2:** Updated the Weedus roadmap for the January plan with stakeholders.
+- **Day 3:** Fixed product errors and identified the app bottleneck.
+- **Day 4:** Addressed vendor team member `/dashboard` refresh issues and fixed retailer team member inventory visibility.
+- **Day 5:** Implemented Vendor Day.
+- **Day 6:** Resolved minor production issues and documented implementation milestones to track product completeness.
+- **Day 7:** Off.
+
 
 ## Weekly Logs
 - [Internship Logs](internship/README.md)

--- a/internship/week30.md
+++ b/internship/week30.md
@@ -1,0 +1,13 @@
+# Week 30 (January 5–January 11, 2026)
+
+## Overview
+- Fixed inventory filtering issues, documented future build plans and milestones, refreshed the Weedus January roadmap with stakeholders, resolved product and performance issues, and delivered vendor-focused dashboard and day initiatives.
+
+## Day-by-Day Summary
+- **Mon:** Fixed the backend inventory filtering logic and unified documentation for future build planning.
+- **Tue:** Updated the Weedus roadmap for the January plan with stakeholders.
+- **Wed:** Fixed product errors and identified the app bottleneck.
+- **Thu:** Addressed vendor team member `/dashboard` refresh issues and fixed retailer team member inventory visibility.
+- **Fri:** Implemented Vendor Day.
+- **Sat:** Resolved minor production issues and documented implementation milestones to track product completeness.
+- **Sun:** Off.


### PR DESCRIPTION
### Motivation
- Keep the repository's weekly work logs up to date by adding the Week 30 summary to the `internship/` logs as required by project guidelines.
- Surface recent backend fixes and roadmap updates in the top-level project documentation so stakeholders and contributors can see progress.
- Record operational fixes (inventory filtering, dashboard refresh, product errors, bottleneck investigation) for traceability and future reference.

### Description
- Added `internship/week30.md` containing the Week 30 overview and day-by-day summary following the repository's log format.
- Extended `README.md` with a Week 30 entry in the chronological summary section to reflect the new log.
- Ensured the new week log follows the `# Week X`, `## Overview`, and `## Day-by-Day Summary` structure mandated by `AGENTS.md`.

### Testing
- Ran `npm test` as instructed by `AGENTS.md` before finishing the change.
- `npm test` failed due to a missing `package.json` at the repository root, so automated tests could not be executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964646423c883208fc70c2159dbe4f2)