### PR TITLE
Add Week 31 internship log and update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,15 @@ This repository tracks progress from my Autosterea Software Engineering internsh
 - **Day 6:** Resolved minor production issues and documented implementation milestones to track product completeness.
 - **Day 7:** Off.
 
+### Week 31 (January 12–January 18, 2026)
+- **Day 1:** Implemented the inquiry module.
+- **Day 2:** Stress-tested production and fixed an issue where deleted or unpublished catalog products removed items from order history.
+- **Day 3:** Dropped unused legacy tables, renamed remaining tables, and fixed the `/deliveries/[id]` page rendering after the database crash.
+- **Day 4:** Ran the Buddy mobile app trial with the new mobile app agent in Replit.
+- **Day 5:** Continued the Buddy mobile app trial with the new mobile app agent in Replit.
+- **Day 6:** Fixed the production console log issue in Weedus.
+- **Day 7:** Off.
+
 
 ## Weekly Logs
 - [Internship Logs](internship/README.md)

--- a/internship/README.md
+++ b/internship/README.md
@@ -32,3 +32,5 @@ This folder contains weekly progress logs for my Autosterea Software Engineering
 - [Week 27](week27.md)
 - [Week 28](week28.md)
 - [Week 29](week29.md)
+- [Week 30](week30.md)
+- [Week 31](week31.md)

--- a/internship/week31.md
+++ b/internship/week31.md
@@ -1,0 +1,13 @@
+# Week 31 (January 12–January 18, 2026)
+
+## Overview
+- Implemented the inquiry module, stress-tested production while fixing order history retention, cleaned up legacy database tables, resolved delivery page rendering after a database crash, trialed a new Buddy mobile app agent, and fixed Weedus production logging issues.
+
+## Day-by-Day Summary
+- **Mon:** Implemented the inquiry module.
+- **Tue:** Stress-tested production and fixed an issue where deleted or unpublished catalog products removed items from order history.
+- **Wed:** Dropped unused legacy tables, renamed remaining tables, and fixed the `/deliveries/[id]` page rendering after the database crash.
+- **Thu:** Ran the Buddy mobile app trial with the new mobile app agent in Replit.
+- **Fri:** Continued the Buddy mobile app trial with the new mobile app agent in Replit.
+- **Sat:** Fixed the production console log issue in Weedus.
+- **Sun:** Off.


### PR DESCRIPTION
### Motivation
- Keep the internship weekly logs up-to-date and document recent production fixes, DB maintenance, and mobile agent trials per repository guidelines. 
- Surface the Week 31 summary in the root README and the internship index so week listings remain contiguous.

### Description
- Added `internship/week31.md` containing an overview and a day-by-day summary for January 12–18, 2026. 
- Updated `README.md` to include the Week 31 summary in the main project timeline. 
- Updated `internship/README.md` to add a link to `week31.md` in the weekly index.

### Testing
- Ran `npm test`, which failed with `ENOENT` because there is no `package.json` in the repository (no other automated tests were present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f10ee303c83208c3c4fb2f15f5bf5)