### PR TITLE
Add week 32 internship log and update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,15 @@ This repository tracks progress from my Autosterea Software Engineering internsh
 - **Day 6:** Fixed the production console log issue in Weedus.
 - **Day 7:** Off.
 
+### Week 32 (January 19–January 25, 2026)
+- **Day 1:** Off.
+- **Day 2:** Bypassed the payment feature with check/ACH and online payment options.
+- **Day 3:** Enhanced the catalog frontend with an Amazon-style image upload flow.
+- **Day 4:** Separated app storage for images, PDFs, and invoices between production and development environments.
+- **Day 5:** Refactored and unified redundant catalog, vendor day, and payment logic across `/components` and `/app`, and finished the login recovery flow (forgot password and find password).
+- **Day 6:** Added vendor day status automation rules so retailers can mark confirmed/modified instances as completed, auto-completed expired instances, and unified the rejected status into canceled.
+- **Day 7:** Enhanced the payment flow by creating deliveries, mapping payment instances 1:1 to deliveries, and syncing payment statuses to delivery statuses while keeping a legacy fallback.
+
 
 ## Weekly Logs
 - [Internship Logs](internship/README.md)

--- a/internship/README.md
+++ b/internship/README.md
@@ -34,3 +34,4 @@ This folder contains weekly progress logs for my Autosterea Software Engineering
 - [Week 29](week29.md)
 - [Week 30](week30.md)
 - [Week 31](week31.md)
+- [Week 32](week32.md)

--- a/internship/week32.md
+++ b/internship/week32.md
@@ -1,0 +1,15 @@
+# Week 32 (January 19–January 25, 2026)
+
+## Overview
+- Bypassed payment features for check/ACH and online options, upgraded the catalog image upload experience, separated storage by environment for media and invoices, refactored redundant catalog/vendor day/payment code, completed the login recovery flow, and refined vendor day status automation plus delivery-to-payment alignment.
+
+## Day-by-Day Summary
+- **Mon:** Off.
+- **Tue:** Bypassed the payment feature with check/ACH and online payment options.
+- **Wed:** Enhanced the catalog frontend with an Amazon-style image upload flow.
+- **Thu:** Separated app storage for images, PDFs, and invoices between production and development environments.
+- **Fri:** Refactored and unified redundant catalog, vendor day, and payment logic across `/components` and `/app`, and finished the login recovery flow (forgot password and find password).
+- **Sat:**
+  - Objectives: add time-based automation management for vendor day and stronger status control tied to time and user action.
+  - Solutions: let retailer users mark "confirmed" or "modified" instances as "completed"; if they do not, automatically switch them to "completed" after the end time passes; unify the "rejected" status into "canceled" and remove "rejected".
+- **Sun:** Enhanced the payment flow by creating a delivery, updating the payment instance for the delivery, and syncing the payment status to the delivery status with a 1:1 mapping for new instances (falling back to the legacy flow for older deliveries).


### PR DESCRIPTION
### Motivation
- Keep the repository's weekly work logs up-to-date per the AGENTS guidelines by adding the Week 32 entry.
- Record and communicate recent backend/frontend work (payment bypass, catalog image upload, storage separation, vendor day automation, login recovery, and delivery↔payment mapping) in the central logs.
- Ensure the top-level documentation and the internship index are synchronized with the new weekly log.

### Description
- Added `internship/week32.md` containing the Week 32 overview and day-by-day summary for January 19–25, 2026.
- Updated `README.md` to include a Week 32 summary section that mirrors the new weekly log.
- Updated `internship/README.md` to add a link to `week32.md` in the index.
- The Week 32 notes enumerate the key changes: payment bypass (check/ACH and online), catalog image upload improvements, environment-separated media/invoice storage, refactors unifying catalog/vendor-day/payment code, login recovery completion, vendor day status automation, and delivery-to-payment sync for new instances.

### Testing
- Ran `npm test`, which failed due to a missing `package.json` in this repository. 
- No other automated tests were present or executed in this workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976ccbfa550832093c91d884202de36)