### PR TITLE
Add Week 33 internship log and update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,15 @@ This repository tracks progress from my Autosterea Software Engineering internsh
 - **Day 6:** Added vendor day status automation rules so retailers can mark confirmed/modified instances as completed, auto-completed expired instances, and unified the rejected status into canceled.
 - **Day 7:** Enhanced the payment flow by creating deliveries, mapping payment instances 1:1 to deliveries, and syncing payment statuses to delivery statuses while keeping a legacy fallback.
 
+### Week 33 (January 26–February 1, 2026)
+- **Day 1:** Translated the Buddy web frontend (React) into the mobile version using React Native.
+- **Day 2:** Worked on the Buddy mobile backend.
+- **Day 3:** Created the appointment feature so users can request and schedule meetings with another business.
+- **Day 4:** Stress-tested appointment instances and enhanced UI/UX patterns.
+- **Day 5:** Added push support to Google Calendar.
+- **Day 6:** Added push support to Apple Calendar.
+- **Day 7:** Off.
+
 
 ## Weekly Logs
 - [Internship Logs](internship/README.md)

--- a/internship/README.md
+++ b/internship/README.md
@@ -35,3 +35,4 @@ This folder contains weekly progress logs for my Autosterea Software Engineering
 - [Week 30](week30.md)
 - [Week 31](week31.md)
 - [Week 32](week32.md)
+- [Week 33](week33.md)

--- a/internship/week33.md
+++ b/internship/week33.md
@@ -1,0 +1,13 @@
+# Week 33 (January 26–February 1, 2026)
+
+## Overview
+Focused on translating the Buddy web experience into a mobile counterpart, extending backend support, and launching appointment scheduling enhancements. Continued with performance testing, UI/UX improvements, and calendar integrations.
+
+## Day-by-Day Summary
+- **Mon:** Translated the Buddy web frontend (React) into the mobile version using React Native.
+- **Tue:** Worked on the Buddy mobile backend.
+- **Wed:** Created the appointment feature so users can request and schedule meetings with another business.
+- **Thu:** Stress-tested appointment instances and enhanced UI/UX patterns.
+- **Fri:** Added push support to Google Calendar.
+- **Sat:** Added push support to Apple Calendar.
+- **Sun:** Off.


### PR DESCRIPTION
### Motivation
- Record progress for Week 33 and surface it in the repository index and main summary so weekly logs stay complete and discoverable.

### Description
- Added `internship/week33.md` with an overview and day-by-day summary, updated `internship/README.md` to link `week33.md`, and extended the root `README.md` Week summaries to include Week 33.

### Testing
- Ran `npm test` as required by repository guidelines and it failed with `ENOENT` due to a missing `package.json` in the repository (no other automated tests were present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fcca073408320888a0ee6e0cfd1fa)